### PR TITLE
Added special case for halt in interactive console

### DIFF
--- a/scripts/rosprolog_commandline.py
+++ b/scripts/rosprolog_commandline.py
@@ -89,7 +89,7 @@ class PQ(object):
         try:
             while not rospy.is_shutdown():
                 cmd = raw_input('?- ')
-                if cmd == 'quit.':
+                if cmd == 'quit.' or cmd == 'halt.':
                     break
                 elif cmd == '':
                     continue


### PR DESCRIPTION
Added special case for halt in interactive console to stop the cmd line tool instead of Prolog interpreter